### PR TITLE
'-_' fixes and add support for 'keywords'

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 Introduction
 ==============
-d2to1 (the 'd' is for 'distutils') allows using distutils2-like setup.cfg files 
+d2to1 (the 'd' is for 'distutils') allows using distutils2-like setup.cfg files
 for a package's metadata with a distribute/setuptools setup.py script.  It
 works by providing a distutils2-formatted setup.cfg file containing all of a
 package's metadata, and a very minimal setup.py which will slurp its arguments
@@ -58,7 +58,9 @@ uses its own machinery to install itself)::
      Topic :: Software Development :: Build Tools
      Topic :: Software Development :: Libraries :: Python Modules
      Topic :: System :: Archiving :: Packaging
- 
+ keywords =
+     setup
+     distutils
  [files]
  packages = d2to1
 

--- a/d2to1/util.py
+++ b/d2to1/util.py
@@ -124,6 +124,8 @@ def cfg_to_args(path='setup.cfg'):
 
     BOOL_FIELDS = ("use_2to3", "zip_safe")
 
+    CSV_FIELDS = ("keywords",)
+
     # The method source code really starts here.
     parser = RawConfigParser()
     if not os.path.exists(path):
@@ -178,6 +180,8 @@ def cfg_to_args(path='setup.cfg'):
             else:
                 continue
 
+        if arg in CSV_FIELDS:
+            in_cfg_value = split_csv(in_cfg_value)
         if arg in MULTI_FIELDS:
             in_cfg_value = split_multiline(in_cfg_value)
         elif arg in BOOL_FIELDS:
@@ -434,6 +438,14 @@ def split_multiline(value):
 
     value = [element for element in
              (line.strip() for line in value.split('\n'))
+             if element]
+    return value
+
+def split_csv(value):
+    """Special behaviour when we have a comma separated options"""
+
+    value = [element for element in
+             (chunk.strip() for chunk in value.split(','))
              if element]
     return value
 


### PR DESCRIPTION
Some of the INI keys were hard-coded to the '-' syntax causing the '_' alternative to fail. This is fixed by uniformising the syntax.
I also added support for the 'keywords' attributes as a CSV field.
