### PR TITLE
Make parse errors meaningful.

### DIFF
--- a/d2to1/core.py
+++ b/d2to1/core.py
@@ -47,8 +47,7 @@ def d2to1(dist, attr, value):
     except:
         e = sys.exc_info()[1]
         raise DistutilsSetupError(
-            'Error parsing %s: %s: %s' % (path, e.__class__.__name__,
-                                          e.args[0]))
+            'Error parsing %s: %s: %s' % (path, e.__class__.__name__, e))
 
     # Repeat some of the Distribution initialization code with the newly
     # provided attrs

--- a/d2to1/util.py
+++ b/d2to1/util.py
@@ -159,8 +159,20 @@ def cfg_to_args(path='setup.cfg'):
                                  os.path.abspath(path))
     parser.read(path)
     config = {}
-    for section in parser.sections():
-        config[section] = dict(parser.items(section))
+    sections = parser.sections()
+    # Sorting ensures that non-os-targetted sections process first
+    sections.sort()
+    for section in sections:
+        if ":" in section:
+            (subsection, os_target) = section.split(':', 1)
+            if sys.platform != os_target:
+                continue
+            if section in config:
+                config[subsection].update(dict(parser.items(section)))
+            else:
+                config[subsection] = dict(parser.items(section))
+        else:
+            config[section] = dict(parser.items(section))
 
     # Run setup_hooks, if configured
     setup_hooks = has_get_option(config, 'global', 'setup_hooks')


### PR DESCRIPTION
This makes the error displays on a bad setup.cfg value go from:

error in setup command: Error parsing setup.cfg: IOError: 2

to

error in setup command: Error parsing setup.cfg: IOError: No such file or
directory: 'README'

Which makes debugging eversomuch better.
