### PR TITLE
Support environment markers in setup.cfg.

### DIFF
--- a/d2to1/extern/markerlib/README
+++ b/d2to1/extern/markerlib/README
@@ -1,0 +1,4 @@
+Markerlib 0.6.0 from https://pypi.python.org/pypi/markerlib/0.6.0
+has been bundled here. According to the upstream repo,
+http://bitbucket.org/dholth/markerlib/, markerlib is licensed under
+the MIT license.

--- a/d2to1/extern/markerlib/__init__.py
+++ b/d2to1/extern/markerlib/__init__.py
@@ -1,0 +1,19 @@
+try:
+    import ast
+    from .markers import default_environment, compile, interpret
+except ImportError:
+    if 'ast' in globals():
+        raise
+    def default_environment():
+        return {}
+    def compile(marker):
+        def marker_fn(environment=None, override=None):
+            # 'empty markers are True' heuristic won't install extra deps.
+            return not marker.strip()
+        marker_fn.__doc__ = marker
+        return marker_fn
+    def interpret(marker, environment=None, override=None):
+        return compile(marker)()
+
+# bw compat
+as_function = compile

--- a/d2to1/extern/markerlib/markers.py
+++ b/d2to1/extern/markerlib/markers.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Interpret PEP 345 environment markers.
+
+EXPR [in|==|!=|not in] EXPR [or|and] ...
+
+where EXPR belongs to any of those:
+
+    python_version = '%s.%s' % (sys.version_info[0], sys.version_info[1])
+    python_full_version = sys.version.split()[0]
+    os.name = os.name
+    sys.platform = sys.platform
+    platform.version = platform.version()
+    platform.machine = platform.machine()
+    platform.python_implementation = platform.python_implementation()
+    a free string, like '2.6', or 'win32'
+
+
+Lately we're going to replace . with _ for consistency.
+"""
+
+__all__ = ['default_environment', 'compile', 'interpret']
+
+from ast import Compare, BoolOp, Attribute, Name, Load, Str, cmpop, boolop
+from ast import parse, copy_location, NodeTransformer
+
+import os
+import platform
+import sys
+import weakref
+
+_builtin_compile = compile
+
+from platform import python_implementation
+
+# restricted set of variables
+_VARS = {'sys.platform': sys.platform,
+         'python_version': '%s.%s' % sys.version_info[:2],
+         # FIXME parsing sys.platform is not reliable, but there is no other
+         # way to get e.g. 2.7.2+, and the PEP is defined with sys.version
+         'python_full_version': sys.version.split(' ', 1)[0],
+         'os.name': os.name,
+         'platform.version': platform.version(),
+         'platform.machine': platform.machine(),
+         'platform.python_implementation': python_implementation(),
+         'extra': None # wheel extension
+        }
+
+for var in list(_VARS.keys()):
+    if '.' in var:
+        _VARS[var.replace('.', '_')] = _VARS[var]
+
+def default_environment():
+    """Return copy of default PEP 385 globals dictionary."""
+    return dict(_VARS)
+
+class ASTWhitelist(NodeTransformer):
+    def __init__(self, statement):
+        self.statement = statement # for error messages
+    
+    ALLOWED = (Compare, BoolOp, Attribute, Name, Load, Str, cmpop, boolop)
+    
+    def visit(self, node):
+        """Ensure statement only contains allowed nodes."""
+        if not isinstance(node, self.ALLOWED):
+            raise SyntaxError('Not allowed in environment markers.\n%s\n%s' %
+                               (self.statement, 
+                               (' ' * node.col_offset) + '^'))
+        return NodeTransformer.visit(self, node)
+    
+    def visit_Attribute(self, node):
+        """Flatten one level of attribute access."""
+        new_node = Name("%s.%s" % (node.value.id, node.attr), node.ctx)
+        return copy_location(new_node, node)
+
+def parse_marker(marker):
+    tree = parse(marker, mode='eval')
+    new_tree = ASTWhitelist(marker).generic_visit(tree)
+    return new_tree
+
+def compile_marker(parsed_marker):
+    return _builtin_compile(parsed_marker, '<environment marker>', 'eval',
+                   dont_inherit=True)
+
+_cache = weakref.WeakValueDictionary()
+
+def compile(marker):
+    """Return compiled marker as a function accepting an environment dict."""
+    try:
+        return _cache[marker]
+    except KeyError:
+        pass
+    if not marker.strip():
+        def marker_fn(environment=None, override=None):
+            """"""
+            return True
+    else:
+        compiled_marker = compile_marker(parse_marker(marker))
+        def marker_fn(environment=None, override=None):
+            """override updates environment"""
+            if override is None:
+                override = {}
+            if environment is None:
+                environment = default_environment()
+            environment.update(override)
+            return eval(compiled_marker, environment)
+    marker_fn.__doc__ = marker
+    _cache[marker] = marker_fn
+    return _cache[marker]
+
+def interpret(marker, environment=None):
+    return compile(marker)(environment)

--- a/d2to1/extern/markerlib/test.py
+++ b/d2to1/extern/markerlib/test.py
@@ -1,0 +1,51 @@
+import os
+
+from nose.tools import assert_true, assert_false, assert_equal, raises
+       
+def test_markers():
+    from markerlib import interpret, default_environment, compile
+    
+    os_name = os.name
+    
+    assert_true(interpret(""))
+    
+    assert_true(interpret("os.name != 'buuuu'"))
+    assert_true(interpret("python_version > '1.0'"))
+    assert_true(interpret("python_version < '5.0'"))
+    assert_true(interpret("python_version <= '5.0'"))
+    assert_true(interpret("python_version >= '1.0'"))
+    assert_true(interpret("'%s' in os.name" % os_name))
+    assert_true(interpret("'%s' in os_name" % os_name))
+    assert_true(interpret("'buuuu' not in os.name"))
+    
+    assert_false(interpret("os.name == 'buuuu'"))
+    assert_false(interpret("os_name == 'buuuu'"))
+    assert_false(interpret("python_version < '1.0'"))
+    assert_false(interpret("python_version > '5.0'"))
+    assert_false(interpret("python_version >= '5.0'"))
+    assert_false(interpret("python_version <= '1.0'"))
+    assert_false(interpret("'%s' not in os.name" % os_name))
+    assert_false(interpret("'%s' not in os_name" % os_name))
+    assert_false(interpret("'buuuu' in os.name and python_version >= '5.0'"))    
+    assert_false(interpret("'buuuu' in os_name and python_version >= '5.0'"))    
+    
+    environment = default_environment()
+    environment['extra'] = 'test'
+    assert_true(interpret("extra == 'test'", environment))
+    assert_false(interpret("extra == 'doc'", environment))
+    
+    @raises(NameError)
+    def raises_nameError():
+        interpret("python.version == '42'")
+    
+    raises_nameError()
+    
+    @raises(SyntaxError)
+    def raises_syntaxError():
+        interpret("(x for x in (4,))")
+        
+    raises_syntaxError()
+    
+    statement = "python_version == '5'"
+    assert_equal(compile(statement).__doc__, statement)
+

--- a/d2to1/zestreleaser.py
+++ b/d2to1/zestreleaser.py
@@ -88,19 +88,19 @@ def releaser_middle(data):
         msg = "Tagging %s" % (version,)
         cmd = 'git tag -s %s -m "%s"' % (version, msg)
         if os.path.isdir('.git/svn'):
-            print "\nEXPERIMENTAL support for git-svn tagging!\n"
+            print("\nEXPERIMENTAL support for git-svn tagging!\n")
             cur_branch = open('.git/HEAD').read().strip().split('/')[-1]
-            print "You are on branch %s." % (cur_branch,)
+            print("You are on branch %s." % (cur_branch,))
             if cur_branch != 'master':
-                print "Only the master branch is supported for git-svn tagging."
-                print "Please tag yourself."
-                print "'git tag' needs to list tag named %s." % (version,)
+                print("Only the master branch is supported for git-svn tagging.")
+                print("Please tag yourself.")
+                print("'git tag' needs to list tag named %s." % (version,))
                 sys.exit()
             cmd = [cmd]
             local_head = open('.git/refs/heads/master').read()
             trunk = open('.git/refs/remotes/trunk').read()
             if local_head != trunk:
-                print "Your local master diverges from trunk.\n"
+                print("Your local master diverges from trunk.\n")
                 # dcommit before local tagging
                 cmd.insert(0, 'git svn dcommit')
             # create tag in svn
@@ -119,18 +119,18 @@ def releaser_middle(data):
         if not isinstance(cmds, list):
             cmds = [cmds]
         if len(cmds) == 1:
-            print "Tag needed to proceed, you can use the following command:"
+            print("Tag needed to proceed, you can use the following command:")
         for cmd in cmds:
-            print cmd
+            print(cmd)
             if utils.ask("Run this command"):
-                print system(cmd)
+                print(system(cmd))
             else:
                 # all commands are needed in order to proceed normally
-                print "Please create a tag for %s yourself and rerun." % \
-                        (self.data['version'],)
+                print("Please create a tag for %s yourself and rerun." %
+                        (self.data['version'],))
                 sys.exit()
         if not self.vcs.tag_exists('v' + self.data['version']):
-            print "\nFailed to create tag %s!" % (self.data['version'],)
+            print("\nFailed to create tag %s!" % (self.data['version'],))
             sys.exit()
 
     # Normally all this does is to return '--formats=zip', which is currently

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifier =
 packages =
     d2to1
     d2to1.extern
+    d2to1.extern.markerlib
 extra_files =
     CHANGES.rst
     LICENSE


### PR DESCRIPTION
- d2to1/extern/markerlib/: Bundle marklerlib 0.6.0.
- d2to1/util.py: Check in_cfg_values for environment markers and remove
  the value if markers are present and do not match.
- d2to1/zestreleaser.py: Use print function instead of print statement
  for py3k compatibility.
- setup.cfg: Package d2to1.extern.markerlib.
